### PR TITLE
fix(math-inline): fix simple mode interaction and fix non-rendering answerBlocks for advanced mode

### DIFF
--- a/packages/math-inline/package.json
+++ b/packages/math-inline/package.json
@@ -10,6 +10,7 @@
     "@material-ui/core": "^3.9.2",
     "@pie-lib/correct-answer-toggle": "^2.1.2",
     "@pie-lib/math-input": "^5.0.4",
+    "@pie-lib/math-toolbar": "^0.9.13",
     "@pie-lib/render-ui": "^4.3.1",
     "classnames": "^2.2.5",
     "debug": "^3.1.0",

--- a/packages/math-inline/src/index.js
+++ b/packages/math-inline/src/index.js
@@ -24,6 +24,7 @@ export default class Match extends HTMLElement {
 
   sessionChanged(s) {
     this._session.answers = s.answers;
+    this._session.response = s.response;
     log('session: ', this._session);
   }
 

--- a/packages/math-inline/src/main.jsx
+++ b/packages/math-inline/src/main.jsx
@@ -24,6 +24,10 @@ export class SimpleQuestionBlockRaw extends React.Component {
     const showAsCorrect = showCorrect || correct;
     const showAsIncorrect = showCorrect && !correct;
 
+    if (!model.config) {
+      return;
+    }
+
     return (
       <div className={classes.expression}>
         {showCorrect || model.disabled ? (
@@ -38,7 +42,7 @@ export class SimpleQuestionBlockRaw extends React.Component {
           <MathToolbar
             classNames={{ editor: classes.responseEditor }}
             latex={session.response || ''}
-            keypadMode="everything"
+            keypadMode={model.config.equationEditor}
             onChange={onSimpleResponseChange}
             onDone={() => {
             }}


### PR DESCRIPTION
This fixes the broken interaction in case mode was simple. There was nothing rendering previously. Now, instead, the users will see a simple math toolbar, with a keypad. 

Also, for advanced mode answer blocks sometimes weren't rendering correctly. This will fix that as well.