### PR TITLE
fix(package.json): Bumped editable-html version

### DIFF
--- a/packages/extended-text-entry/package.json
+++ b/packages/extended-text-entry/package.json
@@ -13,7 +13,7 @@
     "@material-ui/core": "^3.9.2",
     "@material-ui/icons": "^3.0.2",
     "@pie-framework/pie-player-events": "^0.1.0",
-    "@pie-lib/editable-html": "^6.16.3",
+    "@pie-lib/editable-html": "^7.1.17",
     "@pie-lib/render-ui": "^4.3.1",
     "debug": "^3.1.0",
     "lodash.throttle": "^4.1.1",


### PR DESCRIPTION
After you merge and release a new version of `@pie-ui/extended-text-entry` I'm going to test it locally and make another PR in the `pie-elements` repo.