### PR TITLE
fix(ebsr): set model after mc is defined

### DIFF
--- a/packages/ebsr/demo/config.js
+++ b/packages/ebsr/demo/config.js
@@ -64,7 +64,7 @@ module.exports = {
     {
       id: '1',
       element: 'ebsr-element',
-      mode: 'gather',
+      mode: 'evaluate',
       partA,
       partB,
     }

--- a/packages/ebsr/package.json
+++ b/packages/ebsr/package.json
@@ -17,10 +17,6 @@
   "dependencies": {
     "@pie-framework/pie-player-events": "^0.1.0",
     "@pie-ui/multiple-choice": "^4.7.7",
-    "classnames": "^2.2.5",
-    "debug": "^4.1.1",
-    "prop-types": "^15.6.1",
-    "react": "^16.8.1",
-    "react-dom": "^16.8.1"
+    "debug": "^4.1.1"
   }
 }


### PR DESCRIPTION
Set model and session after `multiple-choice` element is defined. 

Scope ebsr tag to special one so wouldn't get in conflict with regular `multiple-choice` elements.