### PR TITLE
feat: Removed `model.config` with properties set directly on model: `…

### DIFF
--- a/packages/categorize/src/categorize/__tests__/__snapshots__/categories.test.jsx.snap
+++ b/packages/categorize/src/categorize/__tests__/__snapshots__/categories.test.jsx.snap
@@ -2,7 +2,7 @@
 
 exports[`categories snapshots disabled 1`] = `
 <WithStyles(GridContent)
-  columns={2}
+  columns={4}
 >
   <WithStyles(Category)
     choices={Array []}
@@ -24,7 +24,7 @@ exports[`categories snapshots disabled 1`] = `
 
 exports[`categories snapshots renders 1`] = `
 <WithStyles(GridContent)
-  columns={2}
+  columns={4}
 >
   <WithStyles(Category)
     choices={Array []}

--- a/packages/categorize/src/categorize/__tests__/__snapshots__/choices.test.jsx.snap
+++ b/packages/categorize/src/categorize/__tests__/__snapshots__/choices.test.jsx.snap
@@ -3,7 +3,7 @@
 exports[`choices snapshots disabled 1`] = `
 <div>
   <WithStyles(GridContent)
-    columns={2}
+    columns={4}
     extraStyle={
       Object {
         "textAlign": "center",
@@ -16,7 +16,7 @@ exports[`choices snapshots disabled 1`] = `
 exports[`choices snapshots empty 1`] = `
 <div>
   <WithStyles(GridContent)
-    columns={2}
+    columns={4}
     extraStyle={
       Object {
         "textAlign": "center",
@@ -35,7 +35,7 @@ exports[`choices snapshots empty 1`] = `
 exports[`choices snapshots empty 2`] = `
 <div>
   <WithStyles(GridContent)
-    columns={2}
+    columns={4}
     extraStyle={
       Object {
         "textAlign": "center",
@@ -52,7 +52,7 @@ exports[`choices snapshots empty 2`] = `
 exports[`choices snapshots renders 1`] = `
 <div>
   <WithStyles(GridContent)
-    columns={2}
+    columns={4}
     extraStyle={
       Object {
         "textAlign": "center",

--- a/packages/categorize/src/categorize/__tests__/__snapshots__/index.test.jsx.snap
+++ b/packages/categorize/src/categorize/__tests__/__snapshots__/index.test.jsx.snap
@@ -19,27 +19,28 @@ exports[`categorize snapshots incorrect 1`] = `
     >
       <WithStyles(Categories)
         categories={Array []}
-        config={
-          Object {
-            "columns": 2,
-          }
-        }
         grid={
           Object {
-            "columns": 1,
-            "rows": 1,
+            "columns": NaN,
+            "rows": NaN,
+          }
+        }
+        model={
+          Object {
+            "categories": Array [],
+            "choices": Array [],
           }
         }
         onDropChoice={[Function]}
         onRemoveChoice={[Function]}
       />
       <WithStyles(Choices)
-        choicePosition="top"
+        choicePosition="above"
         choices={Array []}
-        config={
+        model={
           Object {
-            "columns": 2,
-            "position": "top",
+            "categories": Array [],
+            "choices": Array [],
           }
         }
       />
@@ -67,27 +68,28 @@ exports[`categorize snapshots renders 1`] = `
     >
       <WithStyles(Categories)
         categories={Array []}
-        config={
-          Object {
-            "columns": 2,
-          }
-        }
         grid={
           Object {
-            "columns": 1,
-            "rows": 1,
+            "columns": NaN,
+            "rows": NaN,
+          }
+        }
+        model={
+          Object {
+            "categories": Array [],
+            "choices": Array [],
           }
         }
         onDropChoice={[Function]}
         onRemoveChoice={[Function]}
       />
       <WithStyles(Choices)
-        choicePosition="top"
+        choicePosition="above"
         choices={Array []}
-        config={
+        model={
           Object {
-            "columns": 2,
-            "position": "top",
+            "categories": Array [],
+            "choices": Array [],
           }
         }
       />
@@ -115,27 +117,58 @@ exports[`categorize snapshots renders with feedback 1`] = `
     >
       <WithStyles(Categories)
         categories={Array []}
-        config={
-          Object {
-            "columns": 2,
-          }
-        }
         grid={
           Object {
-            "columns": 1,
-            "rows": 1,
+            "columns": NaN,
+            "rows": NaN,
+          }
+        }
+        model={
+          Object {
+            "categories": Array [],
+            "choices": Array [],
+            "correctness": "correct",
+            "feedback": Object {
+              "correct": Object {
+                "default": "Correct",
+                "type": "default",
+              },
+              "incorrect": Object {
+                "default": "Incorrect",
+                "type": "default",
+              },
+              "partial": Object {
+                "default": "Nearly",
+                "type": "default",
+              },
+            },
           }
         }
         onDropChoice={[Function]}
         onRemoveChoice={[Function]}
       />
       <WithStyles(Choices)
-        choicePosition="top"
+        choicePosition="above"
         choices={Array []}
-        config={
+        model={
           Object {
-            "columns": 2,
-            "position": "top",
+            "categories": Array [],
+            "choices": Array [],
+            "correctness": "correct",
+            "feedback": Object {
+              "correct": Object {
+                "default": "Correct",
+                "type": "default",
+              },
+              "incorrect": Object {
+                "default": "Incorrect",
+                "type": "default",
+              },
+              "partial": Object {
+                "default": "Nearly",
+                "type": "default",
+              },
+            },
           }
         }
       />

--- a/packages/categorize/src/categorize/__tests__/categories.test.jsx
+++ b/packages/categorize/src/categorize/__tests__/categories.test.jsx
@@ -12,9 +12,6 @@ describe('categories', () => {
       id: '1',
       label: 'Category Label',
       grid: { columns: 1, rows: 1 },
-      config: {
-        columns: 2
-      }
     };
 
     const props = { ...defaults, ...extras };

--- a/packages/categorize/src/categorize/__tests__/choices.test.jsx
+++ b/packages/categorize/src/categorize/__tests__/choices.test.jsx
@@ -12,9 +12,6 @@ describe('choices', () => {
       id: '1',
       label: 'Category Label',
       grid: { columns: 1, rows: 1 },
-      config: {
-        columns: 2
-      }
     };
 
     const props = { ...defaults, ...extras };

--- a/packages/categorize/src/categorize/__tests__/index.test.jsx
+++ b/packages/categorize/src/categorize/__tests__/index.test.jsx
@@ -18,15 +18,6 @@ describe('categorize', () => {
       answers: []
     },
     model: {
-      config: {
-        choices: {
-          position: 'top',
-          columns: 2
-        },
-        categories: {
-          columns: 2
-        }
-      },
       choices: [],
       categories: []
     }

--- a/packages/categorize/src/categorize/categories.jsx
+++ b/packages/categorize/src/categorize/categories.jsx
@@ -9,8 +9,8 @@ export class Categories extends React.Component {
   static propTypes = {
     classes: PropTypes.object.isRequired,
     categories: PropTypes.arrayOf(PropTypes.shape(CategoryType)),
-    config: PropTypes.shape({
-      columns: PropTypes.number.isRequired
+    model: PropTypes.shape({
+      categoriesPerRow: PropTypes.number
     }),
     disabled: PropTypes.bool,
     onDropChoice: PropTypes.func.isRequired,
@@ -19,8 +19,8 @@ export class Categories extends React.Component {
   };
 
   static defaultProps = {
-    config: {
-      columns: 4
+    model: {
+      categoriesPerRow: 4
     }
   };
 
@@ -28,7 +28,7 @@ export class Categories extends React.Component {
     const {
       classes,
       categories,
-      config,
+      model,
       disabled,
       onDropChoice,
       onRemoveChoice,
@@ -36,7 +36,7 @@ export class Categories extends React.Component {
     } = this.props;
 
     return (
-      <GridContent columns={config.columns} className={classes.categories}>
+      <GridContent columns={model.categoriesPerRow} className={classes.categories}>
         {categories.map((c, index) => (
           <Category
             grid={grid}

--- a/packages/categorize/src/categorize/choices.jsx
+++ b/packages/categorize/src/categorize/choices.jsx
@@ -16,21 +16,23 @@ export class Choices extends React.Component {
         PropTypes.shape({ empty: PropTypes.bool })
       ])
     ),
-    config: PropTypes.shape({
-      columns: PropTypes.number.isRequired
+    model: PropTypes.shape({
+      choicesPerRow: PropTypes.number,
+      choicesLabel: PropTypes.string
     }),
     disabled: PropTypes.bool,
     choicePosition: PropTypes.string
   };
 
   static defaultProps = {
-    config: {
-      columns: 4
+    model: {
+      choicesPerRow: 4,
+      choicesLabel: ''
     }
   };
 
   render() {
-    const { classes, choices, config, disabled, choicePosition } = this.props;
+    const { classes, choices, model, disabled, choicePosition } = this.props;
     let style = {
       textAlign: 'center'
     };
@@ -41,12 +43,12 @@ export class Choices extends React.Component {
 
     return (
       <div className={classes.wrapper}>
-        {config.label &&
-          config.label !== '' && (
-            <div className={classes.labelHolder}>{config.label}</div>
+        {model.choicesLabel &&
+        model.choicesLabel !== '' && (
+            <div className={classes.labelHolder}>{model.choicesLabel}</div>
           )}
         <GridContent
-          columns={config.columns}
+          columns={model.choicesPerRow}
           className={classes.choices}
           extraStyle={style}
         >

--- a/packages/categorize/src/categorize/index.jsx
+++ b/packages/categorize/src/categorize/index.jsx
@@ -114,11 +114,9 @@ export class Categorize extends React.Component {
   render() {
     const { classes, model, session } = this.props;
     const { showCorrect } = this.state;
+    const { choicesPosition, choicesPerRow, categoriesPerRow } = model;
 
-    const choicePosition =
-      model.config && model.config.choices
-        ? model.config.choices.position
-        : 'above';
+    const choicePosition = choicesPosition || 'above';
 
     const style = {
       flexDirection: this.getPositionDirection(choicePosition)
@@ -133,9 +131,7 @@ export class Categorize extends React.Component {
 
     log('[render] disabled: ', model.disabled);
 
-    const { config } = model;
-
-    const columns = config.choices.columns / config.categories.columns;
+    const columns = choicesPerRow / categoriesPerRow;
 
     const maxLength = categories.reduce((acc, c) => {
       if (c.choices.length > acc) {
@@ -157,7 +153,7 @@ export class Categorize extends React.Component {
           />
           <div className={classes.categorize} style={style}>
             <Categories
-              config={model.config.categories}
+              model={model}
               disabled={model.disabled}
               categories={categories}
               onDropChoice={this.dropChoice}
@@ -166,7 +162,7 @@ export class Categorize extends React.Component {
             />
             <Choices
               disabled={model.disabled}
-              config={model.config.choices}
+              model={model}
               choices={choices}
               choicePosition={choicePosition}
             />


### PR DESCRIPTION
…categoriesPerRow`, `choicesPerRow`, `choicesLabel`, `choicesPosition`

BREAKING CHANGE: `model.config` will not be used anymore. Instead, use `model.categoriesPerRow`, `model.choicesPerRow`, `model.choicesLabel`, `model.choicesPosition`.