### PR TITLE
Add rationale support for several Item Types

### DIFF
--- a/packages/drag-in-the-blank/src/main.js
+++ b/packages/drag-in-the-blank/src/main.js
@@ -11,6 +11,7 @@ const DraggableDragInTheBlank = withDragContext(DragInTheBlank);
 export class Main extends React.Component {
   static propTypes = {
     prompt: PropTypes.string,
+    rationale: PropTypes.string,
     disabled: PropTypes.bool,
     markup: PropTypes.string,
     model: PropTypes.object,
@@ -62,6 +63,15 @@ export class Main extends React.Component {
           onToggle={this.toggleShowCorrect}
         />
         {prompt && <div dangerouslySetInnerHTML={{ __html: prompt }}/>}
+        <br />
+        {
+          model.rationale && (
+            <Collapsible labels={{ hidden: 'Show Rationale', visible: 'Hide Rationale' }}>
+              <div dangerouslySetInnerHTML={{ __html: model.rationale }}/>
+            </Collapsible>
+          )
+        }
+        <br />
         <DraggableDragInTheBlank
           {...modelWithValue}
           onChange={onChange}

--- a/packages/explicit-constructed-response/src/index.js
+++ b/packages/explicit-constructed-response/src/index.js
@@ -53,6 +53,7 @@ export default class InlineDropdown extends HTMLElement {
       let elem = React.createElement(Main, {
         teacherInstructions: this._model.teacherInstructions,
         prompt: this._model.prompt,
+        rationale: this._model.rationale,
         disabled: this._model.disabled,
         choices: this._model.choices,
         markup: this._model.markup,

--- a/packages/explicit-constructed-response/src/main.js
+++ b/packages/explicit-constructed-response/src/main.js
@@ -4,10 +4,13 @@ import isEmpty from 'lodash/isEmpty';
 import CorrectAnswerToggle from '@pie-lib/correct-answer-toggle';
 import { ConstructedResponse } from '@pie-lib/mask-markup';
 import { Collapsible } from '@pie-lib/render-ui';
+import { withStyles } from '@material-ui/core/styles';
 
 export class Main extends React.Component {
   static propTypes = {
+    classes: PropTypes.object.isRequired,
     prompt: PropTypes.string,
+    rationale: PropTypes.string,
     disabled: PropTypes.bool,
     markup: PropTypes.string,
     mode: PropTypes.string,
@@ -37,13 +40,13 @@ export class Main extends React.Component {
 
   render() {
     const { showCorrectAnswer } = this.state;
-    const { mode, prompt, teacherInstructions } = this.props;
+    const { classes, mode, prompt, rationale, teacherInstructions } = this.props;
 
     return (
       <div>
         {
           teacherInstructions && (
-            <div style={{ margin: '16px 0' }}>
+            <div className={classes.collapsible}>
               <Collapsible
                 labels={{ hidden: 'Show Teacher Instructions', visible: 'Hide Teacher Instructions' }}
               >
@@ -58,6 +61,17 @@ export class Main extends React.Component {
           onToggle={this.toggleShowCorrect}
         />
         {prompt && <div dangerouslySetInnerHTML={{ __html: prompt }}/>}
+        {
+          rationale && (
+            <div className={classes.collapsible}>
+              <Collapsible
+                labels={{ hidden: 'Show Rationale', visible: 'Hide Rationale' }}
+              >
+                <div dangerouslySetInnerHTML={{ __html: rationale }}/>
+              </Collapsible>
+            </div>
+          )
+        }
         <ConstructedResponse
           {...this.props}
           showCorrectAnswer={showCorrectAnswer}
@@ -67,4 +81,10 @@ export class Main extends React.Component {
   }
 }
 
-export default Main;
+const styles = theme => ({
+  collapsible: {
+    margin: `${theme.spacing.unit * 2} 0`,
+  }
+});
+
+export default withStyles(styles)(Main);

--- a/packages/inline-dropdown/src/index.js
+++ b/packages/inline-dropdown/src/index.js
@@ -50,6 +50,7 @@ export default class RootInlineDropdown extends HTMLElement {
       this._session.value = normalize(this._session.value, ids);
       let elem = React.createElement(InlineDropdown, {
         prompt: this._model.prompt,
+        rationale: this._model.rationale,
         teacherInstructions: this._model.teacherInstructions,
         disabled: this._model.disabled,
         markup: this._model.markup,

--- a/packages/inline-dropdown/src/inline-dropdown.jsx
+++ b/packages/inline-dropdown/src/inline-dropdown.jsx
@@ -13,6 +13,7 @@ export class InlineDropdown extends React.Component {
     disabled: PropTypes.bool,
     markup: PropTypes.string,
     mode: PropTypes.string,
+    rationale: PropTypes.string,
     teacherInstructions: PropTypes.string,
     choices: PropTypes.object,
     value: PropTypes.object,
@@ -47,7 +48,7 @@ export class InlineDropdown extends React.Component {
 
   render() {
     const { showCorrectAnswer } = this.state;
-    const { prompt, mode, teacherInstructions } = this.props;
+    const { prompt, mode, rationale, teacherInstructions } = this.props;
 
     return (
       <div>
@@ -68,6 +69,16 @@ export class InlineDropdown extends React.Component {
         />
         <br />
         {prompt && <div dangerouslySetInnerHTML={{ __html: prompt }}/>}
+        <br />
+        {
+          rationale && (
+            <Collapsible
+              labels={{ hidden: 'Show Rationale', visible: 'Hide Rationale' }}
+            >
+              <div dangerouslySetInnerHTML={{ __html: rationale }}/>
+            </Collapsible>
+          )
+        }
         <DropDown
           {...this.props}
           showCorrectAnswer={showCorrectAnswer}


### PR DESCRIPTION
Add rationale support for ECR, Drag in the Blank, Inline Dropdown.

Issue reported [here](https://app.clubhouse.io/keydatasystems/story/2626/several-item-types-rationale-missing-from-settings-panel-and-when-toggled-on-item-authoring).