### PR TITLE
fix: set proper dimensions for drawing-response area

### DIFF
--- a/packages/drawing-response/src/drawing-response/container.jsx
+++ b/packages/drawing-response/src/drawing-response/container.jsx
@@ -48,14 +48,23 @@ class Container extends Component {
     };
   }
 
-  componentDidMount() {
-    const { height, width } = this.drawable.getBoundingClientRect();
-    this.setState({
-      drawableDimensions: {
-        height,
-        width
+  setDimensions() {
+    const checkExist = setInterval(() => {
+      const { height, width } = this.drawable.getBoundingClientRect();
+      if (height !== 0 && width !== 0) {
+        this.setState({
+          drawableDimensions: {
+            height,
+            width
+          }
+        });
+        clearInterval(checkExist);
       }
-    })
+    }, 100);
+  }
+
+  componentDidMount() {
+    this.setDimensions();
   }
 
   handleMakeToolActive(tool) {


### PR DESCRIPTION
Should set drawing area dimensions only if container shows up.

This "hack" is required in IBX context, because configuration and preview appear/disappear  using `display: none;` / `display: block;` which won’t let the method `getBoundingClientRect` to do the right thing.

[source](https://stackoverflow.com/questions/4576295/getboundingclientrect-is-returning-zero-in-xul/14384220#14384220)