### PR TITLE
feat: add Part Labels for EBSR and MC

### DIFF
--- a/packages/ebsr/src/index.js
+++ b/packages/ebsr/src/index.js
@@ -66,8 +66,12 @@ export default class Ebsr extends HTMLElement {
         mode,
         keyMode: this._model[key].choicePrefix,
       };
-    }
 
+      const partLabel = part._model.partLabel;
+      const isFirst = key === 'partA';
+      const el = document.getElementById(`${isFirst ? 'first' : 'second'}_label`);
+      el.innerHTML = partLabel || '';
+    }
   }
 
   setPartSession(part, key) {
@@ -115,7 +119,9 @@ export default class Ebsr extends HTMLElement {
   _render() {
     this.innerHTML = `
       <div>
+        <p id="first_label"></p>
         <${MC_TAG_NAME} id="a"></${MC_TAG_NAME}>
+        <p id="second_label"></p>
         <${MC_TAG_NAME} id="b"></${MC_TAG_NAME}>
       </div>
     `;


### PR DESCRIPTION
Should fix the first 2/3 elements from [3555](https://app.clubhouse.io/keydatasystems/story/3555/part-labels-for-ebsr). 

Ideally would be to 
* have one setting panel for EBSR
* update `pie-lib/config-ui/settings` to have a comp like `toggleWithDropdown`; currently we use two diff comps for Part Labels feature (which means two objects in configuration, not sure how good is that, cc. @edeustace ): `toggle` for rendering or not the dropdown and `dropdown` for Letters/Numbers options.

Agreed with @andreeapescar to pass her this task. 