### PR TITLE
fix: major tick normalizes to minor->10*minor

### DIFF
--- a/packages/number-line/src/number-line/graph/__tests__/ticks-utils.test.js
+++ b/packages/number-line/src/number-line/graph/__tests__/ticks-utils.test.js
@@ -1,50 +1,32 @@
 import * as mod from '../tick-utils';
 import * as math from 'mathjs';
 import { AssertionError } from 'assert';
+import isObject from 'lodash/isObject';
+
+const domain = (min, max) => ({ min, max });
+const ticks = (minor, major) => ({ minor, major });
+const fs = f => (isObject(f) ? `${f.n * f.s}/${f.d}` : fs(math.fraction(f)));
+const tickString = ticks =>
+  `minor:${fs(ticks.minor)}, major: ${fs(ticks.major)}`;
+const pf = f => `${f.n * f.s}/${f.d}`;
+const f = (n, d) =>
+  math.fraction.apply(math, [n, d].filter(v => v !== undefined));
 
 describe('ticks', () => {
   describe('normalizeTicks', () => {
-    it('?', () => {
-      const result = mod.normalizeTicks(
-        { min: 0, max: 1000 },
-        { minor: 1, major: 10 }
-      );
-
-      expect(result).toMatchObject({
-        minor: f(10, 1),
-        major: f(20, 1)
+    const assertNormalize = (domain, ticks, expected) => {
+      it(`${domain.min}<->${domain.max}, ${tickString(ticks)} => ${tickString(
+        expected
+      )}`, () => {
+        const result = mod.normalizeTicks(domain, ticks);
+        expect(result).toMatchObject(expected);
       });
-    });
+    };
 
-    it('?', () => {
-      const result = mod.normalizeTicks(
-        { min: -2, max: 1 },
-        { minor: 0.2, major: 0.4 }
-      );
-
-      expect(result).toMatchObject({
-        minor: { s: 1, n: 1, d: 5 },
-        major: { n: 2, d: 5, s: 1 }
-      });
-    });
-
-    it('?', () => {
-      const result = mod.normalizeTicks(
-        { min: -2, max: 1 },
-        { minor: 0.2, major: 0.5 },
-        { limit: false }
-      );
-
-      expect(result).toMatchObject({
-        minor: f(1, 5),
-        major: f(2, 5)
-      });
-    });
+    assertNormalize(domain(0, 100), ticks(1, 10), ticks(f(1, 1), f(10, 1)));
+    assertNormalize(domain(-2, 1), ticks(0.2, 0.4), ticks(f(1, 5), f(2, 5)));
+    assertNormalize(domain(-2, 1), ticks(0.2, 0.5), ticks(f(1, 5), f(2, 5)));
   });
-
-  const pf = f => `${f.n * f.s}/${f.d}`;
-  const f = (n, d) =>
-    math.fraction.apply(math, [n, d].filter(v => v !== undefined));
 
   describe('fractionRange', () => {
     const assertFr = (start, end, interval, expected) => {

--- a/packages/number-line/src/number-line/graph/tick-utils.js
+++ b/packages/number-line/src/number-line/graph/tick-utils.js
@@ -1,6 +1,7 @@
 import * as math from 'mathjs';
 import uniqWith from 'lodash/uniqWith';
-
+import isObject from 'lodash/isObject';
+import { isNumber } from 'util';
 export const fractionSnapTo = (min, max, interval, value) => {
   value = fmax(fmin(value, max), min);
   const mod = value.mod(interval);
@@ -158,22 +159,27 @@ export const isMultiple = (multiple, src) => {
   return math.equal(mod, 0);
 };
 
+/**
+ * Accepts a fraction object {n,d,s} or number.
+ * @param {*} v
+ * @return mathjs.fraction
+ */
+export const fraction = v => {
+  if (isObject(v)) {
+    return math.fraction(v.n * v.s, v.d);
+  } else if (isNumber(v)) {
+    return math.fraction(v);
+  }
+};
+
 export const normalizeTicks = (domain, ticks, opts) => {
   const l = opts ? opts.limit !== false : true;
-  const end = math.fraction(domain.max - domain.min);
+  const end = fraction(domain.max - domain.min);
   const minor = l
-    ? limit(
-        math.fraction(ticks.minor),
-        math.divide(end, 100),
-        math.divide(end, 3)
-      )
+    ? limit(fraction(ticks.minor), math.divide(end, 100), math.divide(end, 3))
     : math.fraction(ticks.minor);
   const major = l
-    ? limit(
-        math.fraction(ticks.major),
-        math.divide(end, 50),
-        math.divide(end, 2)
-      )
+    ? limit(fraction(ticks.major), minor, math.multiply(minor, 10))
     : math.fraction(ticks.major);
 
   const m = isMultiple(major, minor);


### PR DESCRIPTION
normalize logic didn't work when you had a domain of 0->1, with ticks of 0.333333 and 1.

The major tick 1 was getting limited to 1/2 cos of `limit(major, end/50, end/2)` this was not a multiple so it was defaulting to 2xminor.

This change limits the major to be from `minor` -> `10 x minor`.