### PR TITLE
fix: ch6010: Updated the way a choice correctness is determined.

### DIFF
--- a/packages/multiple-choice/src/__tests__/__snapshots__/multiple-choice-test.jsx.snap
+++ b/packages/multiple-choice/src/__tests__/__snapshots__/multiple-choice-test.jsx.snap
@@ -117,6 +117,7 @@ exports[`CorespringChoice snapshot renders incorrect tick if one answer is corre
     <WithStyles(ChoiceInput)
       checked={false}
       className="undefined"
+      correctness="incorrect"
       disabled={false}
       displayKey=""
       feedback="great"

--- a/packages/multiple-choice/src/__tests__/multiple-choice-test.jsx
+++ b/packages/multiple-choice/src/__tests__/multiple-choice-test.jsx
@@ -67,7 +67,8 @@ describe('CorespringChoice', () => {
       let itemChoices = [
         { value: 'a', label: 'label a', correct: true, feedback: 'great' },
         { value: 'b', label: 'label b' },
-        { value: 'c', label: 'label c', feedback: 'great' }
+        { value: 'c', label: 'label c', feedback: 'great' },
+        { value: 'd', label: 'label d', correct: true, feedback: 'great' }
       ];
       let w = mkWrapper({
         mode: 'evaluate',
@@ -77,18 +78,20 @@ describe('CorespringChoice', () => {
         }
       });
 
-      describe('showCorrectToggle disabled', () => {
+      describe('showCorrectToggle disabled (state.showCorrect is false)', () => {
         it('shows choice correctness only if was checked', () => {
-          // this one was selected
+          // this one was selected and is correct
           expect(w.instance().getCorrectness(itemChoices[0])).toEqual('correct');
-          // this one was not selected
+          // this one was not selected and is incorrect
           expect(w.instance().getCorrectness(itemChoices[1])).toEqual(undefined);
-          // this one was selected, but not correct
+          // this one was selected, but is incorrect
           expect(w.instance().getCorrectness(itemChoices[2])).toEqual('incorrect');
+          // this one was not selected and is correct
+          expect(w.instance().getCorrectness(itemChoices[3])).toEqual('incorrect');
         });
       });
 
-      describe('showCorrectToggle enabled', () => {
+      describe('showCorrectToggle enabled (state.showCorrect is true)', () => {
         it('shows choice correctness no matter if was checked or not', () => {
           w.instance().state.showCorrect = true;
 
@@ -98,6 +101,8 @@ describe('CorespringChoice', () => {
           expect(w.instance().getCorrectness(itemChoices[1])).toEqual(undefined);
           // this one is not correct
           expect(w.instance().getCorrectness(itemChoices[2])).toEqual(undefined);
+          // this one is correct
+          expect(w.instance().getCorrectness(itemChoices[3])).toEqual('correct');
         });
       });
     });

--- a/packages/multiple-choice/src/multiple-choice.jsx
+++ b/packages/multiple-choice/src/multiple-choice.jsx
@@ -92,7 +92,23 @@ export class MultipleChoice extends React.Component {
       return isCorrect ? 'correct' : undefined;
     }
 
-    return isChecked ? (isCorrect ? 'correct' : 'incorrect') : undefined;
+    if (isCorrect) {
+      if (isChecked) {
+        // A correct answer is selected: marked with a green checkmark
+        return 'correct';
+      } else {
+        // A correct answer is NOT selected: marked with an orange X
+        return 'incorrect';
+      }
+    } else {
+      if (isChecked) {
+        // An incorrect answer is selected: marked with an orange X
+        return 'incorrect';
+      } else {
+        // An incorrect answer is NOT selected: not marked
+        return undefined;
+      }
+    }
   };
 
   render() {


### PR DESCRIPTION
Evaluate not working correctly for Multiple Select (MC with checkboxes instead of radio buttons)
The expected behaviour is as follows:

A correct answer is NOT selected: marked with an orange X
An incorrect answer is selected: marked with an orange X
A correct answer is selected: marked with a green checkmark
An incorrect answer is NOT selected: not marked