### PR TITLE
fix(math-inline): no session change to be emitted upon mounting

### DIFF
--- a/packages/math-inline/src/main.jsx
+++ b/packages/math-inline/src/main.jsx
@@ -89,8 +89,6 @@ export class Main extends React.Component {
       activeAnswerBlock: '',
       showCorrect: false
     };
-
-    this.callOnSessionChange();
   }
 
   UNSAFE_componentWillMount() {


### PR DESCRIPTION
[ch5517] / PIE-181

This was a minor change as far as lines of code affected but it could be very impactful. I tested locally using pie-ui alone as well as integrated with pie-elements. Was working fine but I'd still like confirmation from @edeustace before merging that this is ok. Or at least one more person to confirm that things work as they should.
