### PR TITLE
fix: ch6219:

### DIFF
--- a/packages/passage/src/__tests__/__snapshots__/stimulus-tabs.test.jsx.snap
+++ b/packages/passage/src/__tests__/__snapshots__/stimulus-tabs.test.jsx.snap
@@ -6,6 +6,7 @@ exports[`stimulus tabs snapshot should render component 1`] = `
     Object {
       "colorPrimary": "StimulusTabs-colorPrimary-2",
       "root": "StimulusTabs-root-1",
+      "tab": "StimulusTabs-tab-3",
     }
   }
   tabs={

--- a/packages/passage/src/stimulus-tabs.jsx
+++ b/packages/passage/src/stimulus-tabs.jsx
@@ -15,12 +15,15 @@ const styles = theme => ({
   },
   colorPrimary: {
     color: 'red',
+  },
+  tab: {
+    fontSize: '0.8125em'
   }
 });
 
 function TabContainer(props) {
   return (
-    <Typography component="div" style={{ padding: 8 * 3 }}>
+    <Typography component="div" style={{ padding: 8 * 3, fontSize: '0.875em' }}>
       {props.children}
     </Typography>
   );
@@ -50,6 +53,7 @@ class StimulusTabs extends React.Component {
               {
               tabs.map( tab => (
                 <Tab
+                  className={classes.tab}
                   key={tab.id}
                   label={<span dangerouslySetInnerHTML={{__html: tab.title}}></span>}
                   value={tab.id}


### PR DESCRIPTION
In DNA OT, when a pair of passages for an item are laid out in two tabs, the labels for the tabs (which display the title of each passage) are rendered too small to comfortably read. (override font-size of 0.875rem from Tab with '0.875em' and 0.8125rem from Typography with '0.8125em')