### PR TITLE
fix: PD-40: In both the PRB and IBX OT, for Classification items

### DIFF
--- a/packages/categorize/src/__tests__/__snapshots__/index.test.js.snap
+++ b/packages/categorize/src/__tests__/__snapshots__/index.test.js.snap
@@ -31,12 +31,6 @@ exports[`categorize renders snapshot 1`] = `
     >
       <WithStyles(Categories)
         categories={Array []}
-        grid={
-          Object {
-            "columns": NaN,
-            "rows": NaN,
-          }
-        }
         model={
           Object {
             "categories": Array [],
@@ -94,12 +88,6 @@ exports[`categorize renders snapshot with rationale 1`] = `
     >
       <WithStyles(Categories)
         categories={Array []}
-        grid={
-          Object {
-            "columns": NaN,
-            "rows": NaN,
-          }
-        }
         model={
           Object {
             "categories": Array [],
@@ -191,12 +179,6 @@ exports[`categorize renders snapshot with teacherInstructions 1`] = `
     >
       <WithStyles(Categories)
         categories={Array []}
-        grid={
-          Object {
-            "columns": NaN,
-            "rows": NaN,
-          }
-        }
         model={
           Object {
             "categories": Array [],

--- a/packages/categorize/src/categorize/__tests__/__snapshots__/categories.test.jsx.snap
+++ b/packages/categorize/src/categorize/__tests__/__snapshots__/categories.test.jsx.snap
@@ -2,7 +2,7 @@
 
 exports[`categories snapshots disabled 1`] = `
 <WithStyles(GridContent)
-  columns={4}
+  columns={1}
   rows={2}
 >
   <WithStyles(Typography)
@@ -16,9 +16,6 @@ exports[`categories snapshots disabled 1`] = `
       }
     />
   </WithStyles(Typography)>
-  <div />
-  <div />
-  <div />
   <WithStyles(Category)
     choices={Array []}
     disabled={true}
@@ -34,15 +31,12 @@ exports[`categories snapshots disabled 1`] = `
     onDropChoice={[Function]}
     onRemoveChoice={[MockFunction]}
   />
-  <div />
-  <div />
-  <div />
 </WithStyles(GridContent)>
 `;
 
 exports[`categories snapshots renders 1`] = `
 <WithStyles(GridContent)
-  columns={4}
+  columns={1}
   rows={2}
 >
   <WithStyles(Typography)
@@ -56,9 +50,6 @@ exports[`categories snapshots renders 1`] = `
       }
     />
   </WithStyles(Typography)>
-  <div />
-  <div />
-  <div />
   <WithStyles(Category)
     choices={Array []}
     grid={
@@ -73,8 +64,5 @@ exports[`categories snapshots renders 1`] = `
     onDropChoice={[Function]}
     onRemoveChoice={[MockFunction]}
   />
-  <div />
-  <div />
-  <div />
 </WithStyles(GridContent)>
 `;

--- a/packages/categorize/src/categorize/__tests__/__snapshots__/category.test.jsx.snap
+++ b/packages/categorize/src/categorize/__tests__/__snapshots__/category.test.jsx.snap
@@ -11,6 +11,7 @@ exports[`category snapshots disabled 1`] = `
       Object {
         "columns": 1,
         "rows": 1,
+        "rowsRepeatValue": "minmax(60px, auto)",
       }
     }
   />
@@ -27,6 +28,7 @@ exports[`category snapshots incorrect 1`] = `
       Object {
         "columns": 1,
         "rows": 1,
+        "rowsRepeatValue": "minmax(60px, auto)",
       }
     }
   >
@@ -50,6 +52,7 @@ exports[`category snapshots renders 1`] = `
       Object {
         "columns": 1,
         "rows": 1,
+        "rowsRepeatValue": "minmax(60px, auto)",
       }
     }
   />

--- a/packages/categorize/src/categorize/__tests__/__snapshots__/index.test.jsx.snap
+++ b/packages/categorize/src/categorize/__tests__/__snapshots__/index.test.jsx.snap
@@ -31,12 +31,6 @@ exports[`categorize snapshots incorrect 1`] = `
     >
       <WithStyles(Categories)
         categories={Array []}
-        grid={
-          Object {
-            "columns": NaN,
-            "rows": NaN,
-          }
-        }
         model={
           Object {
             "categories": Array [],
@@ -92,12 +86,6 @@ exports[`categorize snapshots renders 1`] = `
     >
       <WithStyles(Categories)
         categories={Array []}
-        grid={
-          Object {
-            "columns": NaN,
-            "rows": NaN,
-          }
-        }
         model={
           Object {
             "categories": Array [],
@@ -153,12 +141,6 @@ exports[`categorize snapshots renders with feedback 1`] = `
     >
       <WithStyles(Categories)
         categories={Array []}
-        grid={
-          Object {
-            "columns": NaN,
-            "rows": NaN,
-          }
-        }
         model={
           Object {
             "categories": Array [],

--- a/packages/categorize/src/categorize/categories.jsx
+++ b/packages/categorize/src/categorize/categories.jsx
@@ -70,7 +70,7 @@ export class Categories extends React.Component {
 
             // for each inner array of categories, create a row with category containers
             cat.forEach((c, index) => {
-              const rows = columns ? Math.floor(c.choices.length / columns) + 1 : 1;
+              const rows = Math.floor(c.choices.length / columns) + 1;
 
               items.push(<Category
                 grid={{ rows, columns }}

--- a/packages/categorize/src/categorize/categories.jsx
+++ b/packages/categorize/src/categorize/categories.jsx
@@ -15,17 +15,18 @@ export class Categories extends React.Component {
     classes: PropTypes.object.isRequired,
     categories: PropTypes.arrayOf(PropTypes.shape(CategoryType)),
     model: PropTypes.shape({
-      categoriesPerRow: PropTypes.number
+      categoriesPerRow: PropTypes.number,
+      choicesPerRow: PropTypes.number,
     }),
     disabled: PropTypes.bool,
     onDropChoice: PropTypes.func.isRequired,
     onRemoveChoice: PropTypes.func.isRequired,
-    grid: PropTypes.object
   };
 
   static defaultProps = {
     model: {
-      categoriesPerRow: 4
+      categoriesPerRow: 1,
+      choicesPerRow: 1
     }
   };
 
@@ -37,11 +38,13 @@ export class Categories extends React.Component {
       disabled,
       onDropChoice,
       onRemoveChoice,
-      grid
     } = this.props;
+    const { choicesPerRow, categoriesPerRow } = model;
+
+    const columns = choicesPerRow / categoriesPerRow;
+
     // split categories into an array of arrays (inner array),
     // where each inner array represents how many categories should be displayed on one row
-    const { categoriesPerRow = 0 } = model;
     const chunkedCategories = chunk(categories, categoriesPerRow);
 
     return (
@@ -67,8 +70,10 @@ export class Categories extends React.Component {
 
             // for each inner array of categories, create a row with category containers
             cat.forEach((c, index) => {
+              const rows = columns ? Math.floor(c.choices.length / columns) + 1 : 1;
+
               items.push(<Category
-                grid={grid}
+                grid={{ rows, columns }}
                 onDropChoice={h => onDropChoice(c.id, h)}
                 onRemoveChoice={onRemoveChoice}
                 disabled={disabled}

--- a/packages/categorize/src/categorize/category.jsx
+++ b/packages/categorize/src/categorize/category.jsx
@@ -46,7 +46,10 @@ export class Category extends React.Component {
     return (
       <div className={names}>
         <PlaceHolder
-          grid={grid}
+          grid={{
+            ...grid,
+            rowsRepeatValue: 'minmax(60px, auto)'
+          }}
           onDropChoice={onDropChoice}
           disabled={disabled}
           className={placeholderNames}
@@ -71,7 +74,7 @@ const styles = () => ({
     border: `solid 1px ${orange[500]}`
   },
   placeholder: {
-    minHeight: '100px',
+    minHeight: '60px',
     flex: '1',
     display: 'grid'
   },

--- a/packages/categorize/src/categorize/choice.jsx
+++ b/packages/categorize/src/categorize/choice.jsx
@@ -57,7 +57,6 @@ export class Layout extends React.Component {
 
 const styles = () => ({
   choice: {
-    border: 'solid 1px white',
     cursor: 'pointer',
     height: '100%',
     width: '100%',
@@ -75,7 +74,6 @@ const styles = () => ({
     cursor: 'move'
   },
   card: {
-    height: '100%',
     width: '100%'
   }
 });

--- a/packages/categorize/src/categorize/index.jsx
+++ b/packages/categorize/src/categorize/index.jsx
@@ -120,7 +120,7 @@ export class Categorize extends React.Component {
   render() {
     const { classes, model, session } = this.props;
     const { showCorrect } = this.state;
-    const { choicesPosition, choicesPerRow, categoriesPerRow } = model;
+    const { choicesPosition } = model;
 
     const choicePosition = choicesPosition || 'above';
 
@@ -137,17 +137,6 @@ export class Categorize extends React.Component {
 
     log('[render] disabled: ', model.disabled);
 
-    const columns = choicesPerRow / categoriesPerRow;
-
-    const maxLength = categories.reduce((acc, c) => {
-      if (c.choices.length > acc) {
-        return c.choices.length;
-      } else {
-        return acc;
-      }
-    }, 0);
-    const rows = Math.floor(maxLength / columns) + 1;
-    const grid = { rows, columns };
     const { rowLabels } = model;
 
     return (
@@ -176,19 +165,10 @@ export class Categorize extends React.Component {
           />
         }
         <div className={classes.categorize} style={style}>
-          <div
-            style={{
-              display: 'flex'
-            }}
-          >
+          <div style={{ display: 'flex' }}>
             {
               rowLabels && (
-                <div
-                  style={{
-                    display: 'grid',
-                    marginRight: '20px'
-                  }}
-                >
+                <div style={{ display: 'grid', marginRight: '20px' }}>
                   {rowLabels.map((label, index) => (
                     <div
                       key={index}
@@ -211,7 +191,6 @@ export class Categorize extends React.Component {
               categories={categories}
               onDropChoice={this.dropChoice}
               onRemoveChoice={this.removeChoice}
-              grid={grid}
             />
           </div>
           <Choices


### PR DESCRIPTION
The response containers and draggable tokens are often larger than desirable. (Each row of categories will have its own grid value, each card will occupy only the needed height)

Just in DRAFT until https://github.com/pie-framework/pie-lib/pull/218 is merged & released.