### PR TITLE
fix(categorize): fix choices map null check - PD-879

### DIFF
--- a/packages/categorize/src/categorize/category.jsx
+++ b/packages/categorize/src/categorize/category.jsx
@@ -8,7 +8,7 @@ import { color } from '@pie-lib/render-ui';
 
 export const CategoryType = {
   id: PropTypes.string.isRequired,
-  categoryId: PropTypes.string
+  categoryId: PropTypes.string,
 };
 
 export class Category extends React.Component {
@@ -18,7 +18,7 @@ export class Category extends React.Component {
     disabled: PropTypes.bool,
     classes: PropTypes.object.isRequired,
     onDropChoice: PropTypes.func,
-    onRemoveChoice: PropTypes.func
+    onRemoveChoice: PropTypes.func,
   };
 
   static defaultProps = {};
@@ -27,13 +27,13 @@ export class Category extends React.Component {
     const {
       classes,
       className,
-      choices,
+      choices = [],
       disabled,
       onDropChoice,
       onRemoveChoice,
       grid,
       id,
-      correct
+      correct,
     } = this.props;
 
     const names = classNames(classes.category, className);
@@ -48,7 +48,7 @@ export class Category extends React.Component {
         <PlaceHolder
           grid={{
             ...grid,
-            rowsRepeatValue: 'minmax(60px, auto)'
+            rowsRepeatValue: 'minmax(60px, auto)',
           }}
           onDropChoice={onDropChoice}
           disabled={disabled}
@@ -71,16 +71,16 @@ export class Category extends React.Component {
 }
 const styles = () => ({
   incorrect: {
-    border: `solid 2px ${color.incorrect()}`
+    border: `solid 2px ${color.incorrect()}`,
   },
   placeholder: {
     minHeight: '60px',
     flex: '1',
-    display: 'grid'
+    display: 'grid',
   },
   category: {
     display: 'flex',
-    flexDirection: 'column'
-  }
+    flexDirection: 'column',
+  },
 });
 export default withStyles(styles)(Category);

--- a/packages/categorize/src/categorize/choices.jsx
+++ b/packages/categorize/src/categorize/choices.jsx
@@ -13,28 +13,34 @@ export class Choices extends React.Component {
     choices: PropTypes.arrayOf(
       PropTypes.oneOfType([
         PropTypes.shape(ChoiceType),
-        PropTypes.shape({ empty: PropTypes.bool })
+        PropTypes.shape({ empty: PropTypes.bool }),
       ])
     ),
     model: PropTypes.shape({
       choicesPerRow: PropTypes.number,
-      choicesLabel: PropTypes.string
+      choicesLabel: PropTypes.string,
     }),
     disabled: PropTypes.bool,
-    choicePosition: PropTypes.string
+    choicePosition: PropTypes.string,
   };
 
   static defaultProps = {
     model: {
       choicesPerRow: 4,
-      choicesLabel: ''
-    }
+      choicesLabel: '',
+    },
   };
 
   render() {
-    const { classes, choices, model, disabled, choicePosition } = this.props;
+    const {
+      classes,
+      choices = [],
+      model,
+      disabled,
+      choicePosition,
+    } = this.props;
     let style = {
-      textAlign: 'center'
+      textAlign: 'center',
     };
 
     if (choicePosition === 'left') {
@@ -43,10 +49,9 @@ export class Choices extends React.Component {
 
     return (
       <div className={classes.wrapper}>
-        {model.choicesLabel &&
-        model.choicesLabel !== '' && (
-            <div className={classes.labelHolder}>{model.choicesLabel}</div>
-          )}
+        {model.choicesLabel && model.choicesLabel !== '' && (
+          <div className={classes.labelHolder}>{model.choicesLabel}</div>
+        )}
         <GridContent
           columns={model.choicesPerRow}
           className={classes.choices}
@@ -70,20 +75,20 @@ export class Choices extends React.Component {
   }
 }
 
-const styles = theme => ({
+const styles = (theme) => ({
   wrapper: {
     flex: 1,
-    padding: theme.spacing.unit
+    padding: theme.spacing.unit,
   },
   choices: {
     paddingTop: theme.spacing.unit,
-    paddingBottom: theme.spacing.unit
+    paddingBottom: theme.spacing.unit,
   },
   labelHolder: {
     margin: '0 auto',
     textAlign: 'center',
-    paddingTop: theme.spacing.unit
-  }
+    paddingTop: theme.spacing.unit,
+  },
 });
 
 export default withStyles(styles)(Choices);

--- a/packages/fill-in-the-blank/src/choices/index.jsx
+++ b/packages/fill-in-the-blank/src/choices/index.jsx
@@ -11,12 +11,12 @@ export class Choices extends React.Component {
     className: PropTypes.string,
     choices: PropTypes.array.isRequired,
     label: PropTypes.string,
-    disabled: PropTypes.bool
+    disabled: PropTypes.bool,
   };
 
   static defaultProps = {};
   render() {
-    const { classes, className, choices, label, disabled } = this.props;
+    const { classes, className, choices = [], label, disabled } = this.props;
     return (
       <div className={classNames(classes.choices, className)}>
         {label && <div className={classes.label}>{label}</div>}
@@ -33,22 +33,22 @@ export class Choices extends React.Component {
   }
 }
 
-const styles = theme => ({
+const styles = (theme) => ({
   choices: {
     padding: theme.spacing.unit,
     marginTop: theme.spacing.unit,
-    border: `solid 1px ${color.primaryLight()}`
+    border: `solid 1px ${color.primaryLight()}`,
   },
   label: {
-    textAlign: 'center'
+    textAlign: 'center',
   },
   choicesContainer: {
     display: 'flex',
-    justifyContent: 'center'
+    justifyContent: 'center',
   },
   choiceHolder: {
-    margin: theme.spacing.unit
-  }
+    margin: theme.spacing.unit,
+  },
 });
 
 export default withStyles(styles)(Choices);

--- a/packages/likert/src/likert.jsx
+++ b/packages/likert/src/likert.jsx
@@ -1,25 +1,25 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import ChoiceInput from './choice-input';
-import {withStyles} from '@material-ui/core/styles';
-import {Collapsible} from '@pie-lib/render-ui';
-import {LIKERT_ORIENTATION} from './likertEntities';
-
+import { withStyles } from '@material-ui/core/styles';
+import { Collapsible } from '@pie-lib/render-ui';
+import { LIKERT_ORIENTATION } from './likertEntities';
 
 const styles = {
   corespringChoice: {
     '& *': {
-      fontFamily: 'Roboto, Arial, Helvetica, sans-serif', '-webkit-font-smoothing': 'antialiased'
+      fontFamily: 'Roboto, Arial, Helvetica, sans-serif',
+      '-webkit-font-smoothing': 'antialiased',
     },
   },
   prompt: {
     verticalAlign: 'middle',
     color: 'var(--pie-primary-text, var(--pie-text, #000000))',
-    paddingBottom: '20px'
+    paddingBottom: '20px',
   },
   choicesWrapper: {
-    display: 'flex'
-  }
+    display: 'flex',
+  },
 };
 
 export class Likert extends React.Component {
@@ -31,11 +31,10 @@ export class Likert extends React.Component {
     disabled: PropTypes.bool.isRequired,
     onSessionChange: PropTypes.func.isRequired,
     likertOrientation: PropTypes.string.isRequired,
-    classes: PropTypes.object.isRequired
+    classes: PropTypes.object.isRequired,
   };
 
-  UNSAFE_componentWillReceiveProps() {
-  }
+  UNSAFE_componentWillReceiveProps() {}
 
   isSelected(value) {
     return this.props.session && this.props.session.value === value;
@@ -44,15 +43,16 @@ export class Likert extends React.Component {
   render() {
     const {
       disabled,
-      choices,
+      choices = [],
       prompt,
       onSessionChange,
       teacherInstructions,
       classes,
-      likertOrientation
+      likertOrientation,
     } = this.props;
 
-    const flexDirection = likertOrientation === LIKERT_ORIENTATION.vertical ? 'column' : 'row';
+    const flexDirection =
+      likertOrientation === LIKERT_ORIENTATION.vertical ? 'column' : 'row';
 
     return (
       <div className={classes.corespringChoice}>
@@ -63,16 +63,16 @@ export class Likert extends React.Component {
               visible: 'Hide Teacher Instructions',
             }}
           >
-            <div dangerouslySetInnerHTML={{__html: teacherInstructions}}/>
+            <div dangerouslySetInnerHTML={{ __html: teacherInstructions }} />
           </Collapsible>
         )}
-        <br/>
-        <br/>
+        <br />
+        <br />
         <div
           className={classes.prompt}
-          dangerouslySetInnerHTML={{__html: prompt}}
+          dangerouslySetInnerHTML={{ __html: prompt }}
         />
-        <div className={classes.choicesWrapper} style={{flexDirection}}>
+        <div className={classes.choicesWrapper} style={{ flexDirection }}>
           {choices.map((choice, index) => (
             <ChoiceInput
               key={`choice-${index}`}
@@ -83,8 +83,7 @@ export class Likert extends React.Component {
               onChange={onSessionChange}
               likertOrientation={likertOrientation}
               checked={this.isSelected(choice.value)}
-            >
-            </ChoiceInput>
+            ></ChoiceInput>
           ))}
         </div>
       </div>
@@ -94,7 +93,7 @@ export class Likert extends React.Component {
 
 Likert.defaultProps = {
   session: {
-    value: []
+    value: [],
   },
 };
 

--- a/packages/multiple-choice/src/multiple-choice.jsx
+++ b/packages/multiple-choice/src/multiple-choice.jsx
@@ -185,7 +185,7 @@ export class MultipleChoice extends React.Component {
     const {
       mode,
       disabled,
-      choices,
+      choices = [],
       choiceMode,
       prompt,
       onChoiceChanged,


### PR DESCRIPTION
Some interactions were simply reliant on the choices array being present. This way at least it won't break the interaction down entirely if it's missing. `3eb3a4ac-eccb-11ea-a4dd-b27091dc957b` breaks it entirely.