### PR TITLE
fix(graphing) set correct colors in "showing-correct" state

### DIFF
--- a/packages/graphing/src/main.jsx
+++ b/packages/graphing/src/main.jsx
@@ -61,7 +61,7 @@ export class Main extends React.Component {
             disabled={true}
             domain={domain}
             labels={labels}
-            marks={correctResponse}
+            marks={correctResponse.map(i => ({ ...i, correctness: 'correct' }))}
             onChangeMarks={onAnswersChange}
             range={range}
             size={size}


### PR DESCRIPTION
See PD-215/PD-572 issue.

This is the quickest solution and I’ve opted to make it so because for “correct” and “incorrect” answers we have only one color (correct-color or incorrect-color).

In order to have 4 shades of green we could add a new property for pie-lib/graphing of `showingCorrect` and depending on that we show those 4 colors. Also, if we do this it would be indicate to add 4 shades of colors for “correct” or “incorrect” answers as well. 